### PR TITLE
Added main() func and entry_points

### DIFF
--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -489,8 +489,7 @@ class Message(OleFile.OleFileIO):
                 print("Directory: " + str(dir))
                 print("Contents: " + self._getStream(dir))
 
-
-if __name__ == "__main__":
+def main():
     if len(sys.argv) <= 1:
         print(__doc__)
         print("""
@@ -533,3 +532,6 @@ Usage:  <file> [file2 ...]
                 # msg.debug()
                 print("Error with file '" + filename + "': " +
                       traceback.format_exc())
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,9 @@ setup(
     scripts=[main_script],
     py_modules=[main_module],
     install_requires=dependencies,
+    entry_points={
+          'console_scripts': [
+              'ExtractMsg = ExtractMsg.__main__:main'
+          ]
+      }
 )


### PR DESCRIPTION
Created a `main()` function in `ExtractMsg.py` so that we can define a value for `entry_points` in `setup.py`, meaning that we should be able to directly call `ExtractMsg` from the command line.