### PR TITLE
Packaging and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install:
+  - python setup.py install
+script:
+  - python tests.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+PYTHON = python
+ARGS =
+
+# In not in a virtualenv, add --user options for install commands.
+INSTALL_OPTS = `$(PYTHON) -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')"`
+
+install:  ## Install this package as current user in "edit" mode.
+	$(PYTHON) setup.py develop $(INSTALL_OPTS)
+
+test:  ## Run tests.
+	$(PYTHON) tests.py
+
+clean:  ## Remove all build files.
+	rm -rf `find . -type d -name __pycache__ \
+		-o -type f -name \*.bak \
+		-o -type f -name \*.orig \
+		-o -type f -name \*.pyc \
+		-o -type f -name \*.pyd \
+		-o -type f -name \*.pyo \
+		-o -type f -name \*.rej \
+		-o -type f -name \*.so \
+		-o -type f -name \*.~ \
+		-o -type f -name \*\$testfn`
+	rm -rf \
+		*.core \
+		*.egg-info \
+		*\$testfn* \
+		.coverage \
+		.tox \
+		build/ \
+		dist/ \
+		docs/_build/ \
+		htmlcov/ \
+		venv \
+		2013-11-18_1026* \
+		tmp/
+
+help: ## Display callable targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ install:  ## Install this package as current user in "edit" mode.
 test:  ## Run tests.
 	$(PYTHON) tests.py
 
+upload:  ## Upload source tarball on PYPI. Requires a .pypirc file in the home dir.
+	$(PYTHON) setup.py sdist upload
+
 clean:  ## Remove all build files.
 	rm -rf `find . -type d -name __pycache__ \
 		-o -type f -name \*.bak \

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,1 +1,0 @@
-olefile

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import glob
 import os
 from setuptools import setup
 import re
@@ -23,7 +22,7 @@ version = match.groupdict()['version']
 
 # read in the dependencies from the virtualenv requirements file
 dependencies = []
-filename = os.path.join("REQUIREMENTS")
+filename = os.path.join("requirements.txt")
 with open(filename, 'r') as stream:
     for line in stream:
         package = line.strip().split('#')[0]

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,53 @@
+import shutil
+import os
+import unittest
+
+import ExtractMsg
+
+
+TEST_FILE = "example-msg-files/unicode.msg"
+
+
+class TestCase(unittest.TestCase):
+
+    def setUp(self):
+        shutil.rmtree("raw", ignore_errors=True)
+        for name in os.listdir('.'):
+            if os.path.isdir(name) and name.startswith('2013-11-18_1026'):
+                shutil.rmtree(name, ignore_errors=True)
+
+    tearDown = setUp
+
+    def test_message(self):
+        msg = ExtractMsg.Message(TEST_FILE)
+        self.assertEqual(msg.subject, u'Test for TIF files')
+        self.assertEqual(
+            msg.body,
+            u'This is a test email to experiment with the MS Outlook MSG '
+            u'Extractor\r\n\r\n\r\n-- \r\n\r\n\r\nKind regards'
+            u'\r\n\r\n\r\n\r\n\r\nBrian Zhou\r\n\r\n')
+        self.assertEqual(msg.date, 'Mon, 18 Nov 2013 10:26:24 +0200')
+        self.assertEqual(msg.parsedDate, (2013, 11, 18, 10, 26, 24, 0, 1, -1))
+        self.assertEqual(msg.sender, 'Brian Zhou <brizhou@gmail.com>')
+        self.assertEqual(msg.to, 'brianzhou@me.com')
+        self.assertEqual(msg.cc, 'Brian Zhou <brizhou@gmail.com>')
+        self.assertEqual(len(msg.attachments), 2)
+        msg.dump()
+        msg.debug()
+
+    def test_save(self):
+        msg = ExtractMsg.Message(TEST_FILE)
+        msg.save()
+        self.assertEqual(
+            sorted(os.listdir('2013-11-18_1026 Test for TIF files')),
+            sorted(['message.text', 'import OleFileIO.tif',
+                    'raised value error.tif']))
+        msg.saveRaw()
+
+    def test_saveRaw(self):
+        msg = ExtractMsg.Message(TEST_FILE)
+        msg.saveRaw()
+        assert os.listdir('raw')
+
+
+unittest.main(verbosity=2)


### PR DESCRIPTION
Different things are going on here:

- add a `Makefile` for various tasks
- add basic unit tests (run them with `make test`)
- add `.travis.yml` for integration with Travis CI. I didn't test this 'cause I had to configure travis. The admin of this project should configure it, and you can do it from https://github.com/mattgwwalker/msg-extractor/settings "ingration and services" tab then follow instructions on how to integrate travis. 
For the record, in case you're not familiar with travis, it's a service which automatically run tests on git push and it looks like this: https://travis-ci.org/giampaolo/psutil
- extra: later, travis can also be configure to run tests on OSX

This PR also paves the way to upload msg-extractor to PYPI (which is my main concern). You'll need to register an account on https://pypi.python.org/pypi first, then put a `.pypirc` file in your home directory which looks like this:

```
[distutils]
index-servers =
    pypi

[pypi]
username: yourusername
password: yourpassword
```

Finally, when you want to upload a new version just run `make upload`.