### PR TITLE
Change str() to .encode('utf-8') to avoid UnicodeEncodeError

### DIFF
--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -432,7 +432,7 @@ class Message(OleFile.OleFileIO):
                 f.write("Subject: " + xstr(self.subject) + "\n")
                 f.write("Date: " + xstr(self.date) + "\n")
                 f.write("-----------------\n\n")
-                f.write(self.body)
+                f.write(self.body.encode('utf-8'))
 
             f.close()
 

--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -410,7 +410,8 @@ class Message(OleFile.OleFileIO):
             attachmentNames = []
             # Save the attachments
             for attachment in self.attachments:
-                attachmentNames.append(attachment.save())
+                if attachment.data is not None:
+                    attachmentNames.append(attachment.save())
 
             if toJson:
                 import json

--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -405,7 +405,7 @@ class Message(OleFile.OleFileIO):
             # From, to , cc, subject, date
 
             def xstr(s):
-                return '' if s is None else str(s)
+                return '' if s is None else s.encode('utf-8')
 
             attachmentNames = []
             # Save the attachments


### PR DESCRIPTION
Smart quotes seem to cause the script to blow up. Encoding with utf-8 resolves this issue.  
  
This has only been tested with Python 2.7.10