### PR TITLE
Fixing  bug in xstr(s)

### DIFF
--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -399,7 +399,7 @@ class Message(OleFile.OleFileIO):
         try:
             os.chdir(dirName)
 
-            # Save the message body fext = 'json' if toJson else 'text'
+            # Save the message body
             fext = 'json' if toJson else 'text' 
             f = open("message." + fext, "w")
             # From, to , cc, subject, date

--- a/ExtractMsg.py
+++ b/ExtractMsg.py
@@ -399,13 +399,13 @@ class Message(OleFile.OleFileIO):
         try:
             os.chdir(dirName)
 
-            # Save the message body
-            fext = 'json' if toJson else 'text'
+            # Save the message body fext = 'json' if toJson else 'text'
+            fext = 'json' if toJson else 'text' 
             f = open("message." + fext, "w")
             # From, to , cc, subject, date
 
             def xstr(s):
-                return '' if s is None else str(s)
+                return ''.encode('utf-8') if s is None else (s.encode('utf-8'))
 
             attachmentNames = []
             # Save the attachments


### PR DESCRIPTION
Changes definition of function `xstr` (line 407), fixing broken `str(s)` for method `s.encode`.

Bug found when using argument `--json` for ExtractMsg.py . Argument `--raw` is still working after the fix.