### PR TITLE
Add tzlocal to requirements files

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,2 +1,3 @@
 olefile
 imapclient
+tzlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 imapclient
 olefile
+tzlocal


### PR DESCRIPTION
Hey, neat project!

I've noticed that whether I'm using the py2 version at v0.20 or the newer py3 version at HEAD, they need `tzlocal` installed.

Not sure whether the intention is to use the REQUIREMENTS file or requirements.txt, so I've gone ahead and added it to both. Happy to change that.