### PR TITLE
Some fixes on recipients.py

### DIFF
--- a/extract_msg/recipient.py
+++ b/extract_msg/recipient.py
@@ -14,10 +14,10 @@ class Recipient(object):
         self.__msg = msg  # Allows calls to original msg file
         self.__dir = '__recip_version1.0_#' + num.rjust(8, '0')
         self.__props = Properties(msg._getStream(self.__dir + '/__properties_version1.0'), constants.TYPE_RECIPIENT)
-        self.__email = msg._getStringStream(self.__dir + '/__substg1.0_39FE')
+        self.__email = msg._getStringStream(self.__dir + '/__substg1.0_3003')
         self.__name = msg._getStringStream(self.__dir + '/__substg1.0_3001')
         self.__type = self.__props.get('0C150003').value
-        self.__formatted = '{0} <{1}>'.format(self.__name, self.__email)
+        self.__formatted = u'{0} <{1}>'.format(self.__name, self.__email)
 
     @property
     def email(self):


### PR DESCRIPTION
fix unicode __formatted variable
fix ID 'email' stream

Here ares som fixes I had to push on my repo.

I actually had **one error** with my python 2.7.13 on this line (everything's fine on 3.5) :
self.__formatted = '{0} <{1}>'.format(self.__name, self.__email)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xee' in position 4: ordinal not in range(128)
I guess it comes from how python 2 deals with string unicode.
So I just added **'u'** character in front of the string.

Also, I changed the ID email Stream 0_39FE by **0_3003** in order to get email addresses from recepients (otherwise I got only **'None'** values)
**reference : MS-OXPROPS**
> 2.672 PidTagEmailAddress 
> Canonical name: PidTagEmailAddress 
> Description: Contains the email address of a Message object. 
> Property ID: **0x3003** 
> Data type: PtypString, 0x001F 

So feel free to merge if you think it's legit. Or we can exchange about it if you think I misunderstood some stuff.