### PR TITLE
Encoding problems while dealing with French mails

### DIFF
--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -445,8 +445,6 @@ class Message(olefile.OleFileIO):
                 pass
             except TypeError:
                 pass
-            except UnicodeDecodeError:
-                self._body = self._body.decode("latin-1")
             if self._body:
                 self._body = encode(self._body)
                 a = re.search('\n', self._body)

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -3,6 +3,7 @@ import email.utils
 import json
 import logging
 import re
+import chardet
 
 from imapclient.imapclient import decode_utf7
 import olefile
@@ -220,6 +221,10 @@ class Message(olefile.OleFileIO):
             return self._header
         except AttributeError:
             headerText = self._getStringStream('__substg1.0_007D')
+            try:
+                headerText = headerText.decode("utf-8")
+            except AttributeError:
+                pass
             if headerText is not None:
                 self._header = EmailParser().parsestr(headerText)
                 self._header['date'] = self.date
@@ -433,6 +438,15 @@ class Message(olefile.OleFileIO):
             return self._body
         except AttributeError:
             self._body = self._getStringStream('__substg1.0_1000')
+            try:
+                enc = chardet.detect(self._body)["encoding"]
+                self._body = self._body.decode(enc)
+            except AttributeError:
+                pass
+            except TypeError:
+                pass
+            except UnicodeDecodeError:
+                self._body = self._body.decode("latin-1")
             if self._body:
                 self._body = encode(self._body)
                 a = re.search('\n', self._body)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@
 imapclient==2.1.0
 olefile==0.46
 tzlocal==1.5.1
+chardet==3.0.4
+


### PR DESCRIPTION
- [ ] Issue #75
- [ ] I added chardet in requirements
- [ ] Nothing has been changed in changelog (no new feature or something like that)
- [ ] I didn't change the version number
- [ ] No test added
- [ ] Ensured your code is as close to PEP 8 compliant as possible? A very few things have been changed


Hello,

Thanks for your awesome work, ole files are such a mess ! 

I've encountered a few problems while dealing with French msg files. It looks like someone has a similar problem in issue #75. 

"Le Français c'est compliqué" and we love weird encodings.

On my test file the headers were loaded as a byte sequence (text utf-8 encoded), so I added code to decode them (if necessary).

I had another error after solving this problem, when decoding the body, mine was also encoded and considered as a byte object too.

```
In [3]: Message("../test.msg")                                                                                                                                                                              
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/Documents/msg-extractor/extract_msg/message.py in attachments(self)
    468         try:
--> 469             return self._attachments
    470         except AttributeError:

AttributeError: 'Message' object has no attribute '_attachments'

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
~/Documents/msg-extractor/extract_msg/message.py in body(self)
    436         try:
--> 437             return self._body
    438         except AttributeError:

AttributeError: 'Message' object has no attribute '_body'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-3-8d7cbad23399> in <module>
----> 1 Message("../test.msg")

~/Documents/msg-extractor/extract_msg/message.py in __init__(self, path, prefix, attachmentClass, filename)
     85         self.header
     86         self.recipients
---> 87         self.attachments
     88         self.to
     89         self.cc

~/Documents/msg-extractor/extract_msg/message.py in attachments(self)
    480 
    481             for attachmentDir in attachmentDirs:
--> 482                 self._attachments.append(self.__attachmentClass(self, attachmentDir))
    483 
    484             return self._attachments

~/Documents/msg-extractor/extract_msg/attachment.py in __init__(self, msg, dir_)
     50                 self.__prefix = msg.prefixList + [dir_, '__substg1.0_3701000D']
     51                 self.__type = 'msg'
---> 52                 self.__data = msg.__class__(self.msg.path, self.__prefix, self.__class__)
     53         else:
     54             # TODO Handling for special attacment types (like 0x00000007)

~/Documents/msg-extractor/extract_msg/message.py in __init__(self, path, prefix, attachmentClass, filename)
     91         self.date
     92         self.__crlf = '\n'  # This variable keeps track of what the new line character should be
---> 93         self.body
     94 
     95     def listDir(self, streams=True, storages=False):

~/Documents/msg-extractor/extract_msg/message.py in body(self)
    440             if self._body:
    441                 self._body = encode(self._body)
--> 442                 a = re.search('\n', self._body)
    443                 if a is not None:
    444                     if re.search('\r\n', self._body) is not None:

/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/re.py in search(pattern, string, flags)
    181     """Scan through string looking for a match to the pattern, returning
    182     a Match object, or None if no match was found."""
--> 183     return _compile(pattern, flags).search(string)
    184 
    185 def sub(pattern, repl, string, count=0, flags=0):

TypeError: cannot use a string pattern on a bytes-like object
```

I added a decoding sequence based on chardet and it solved the problem.

This code works on all the msg files I have on my machine using python 3.7. It's probably not the best way to solve this problem so feel free to refuse my PR, but if it can help improving this tool I'll be happy ! 
Don't hesitate to ask any question you could have.
