### PR TITLE
Version 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.26.2**
+* Fixed error in `Message._registerNamedProperty` where I put the exception `KeyError` instead of `AttributeError`
+
 **v0.26.1**
 * Fixed an issue in `openMsg` that would leave the basic `MSGFile` instance open with the function returned, even if the function was returning a specific msg instance.
 

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.26.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.26.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.26.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.26.2/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2020-08-08'
-__version__ = '0.26.1'
+__version__ = '0.26.2'
 
 import logging
 

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -93,7 +93,7 @@ class Message(MSGFile):
         if self.attachmentsDelayed and not self.attachmentsReady:
             try:
                 self.__waitingProperties
-            except KeyError:
+            except AttributeError:
                 self.__waitingProperties = []
             self.__waitingProperties.append((entry, _type, name))
         else:


### PR DESCRIPTION
**v0.26.2**
* Fixed error in `Message._registerNamedProperty` where I put the exception `KeyError` instead of `AttributeError`.