### PR TITLE
v0.27.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v0.27.3**
+* [[mattgwwalker #105](https://github.com/mattgwwalker/msg-extractor/issues/105)] Added code to fix an internal msg issue that had recipient lists being split up in the header after a certain amount of characters. This was now a bug on our part, but an issue with the generation of the msg file itself.
+* Exposed the `MessageBase` class directly from extract_msg. I forgot to do this when I created it.
+* Added `MessageBase.bcc`. I think it used to exist but got erased somehow on accident. Either way, it exists now.
+
 **v0.27.2**
 * After much debate, I have finally decided to allow an option to override the string encoding in message files. This Was something I reserved solely for `dev_classes.Message` because it felt like it didn't fit with how msg files were supposed to work. I also didn't want messages from people about them running into errors after they overrode the encoding. You can now do this by providing the `overrideEncoding` option on any `MSGFile` class as well as the `openMsg` function.
 * [[mattgwwalker #103](https://github.com/mattgwwalker/msg-extractor/issues/103)] Implemented correct detection of encodings. If you have any more issues with "'X' codec can't decode bytes" it is likely because the encoding specified inside the msg file is wrong.

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.3-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.3/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
-__date__ = '2020-08-26'
-__version__ = '0.27.2'
+__date__ = '2020-08-30'
+__version__ = '0.27.3'
 
 import logging
 
@@ -38,6 +38,7 @@ from extract_msg.attachment import Attachment
 from extract_msg.contact import Contact
 from extract_msg.exceptions import UnrecognizedMSGTypeError
 from extract_msg.message import Message
+from extract_msg.message_base import MessageBase
 from extract_msg.msg import MSGFile
 from extract_msg.prop import create_prop
 from extract_msg.properties import Properties


### PR DESCRIPTION
**v0.27.3**
* [[mattgwwalker #105](https://github.com/mattgwwalker/msg-extractor/issues/105)] Added code to fix an internal msg issue that had recipient lists being split up in the header after a certain amount of characters. This was now a bug on our part, but an issue with the generation of the msg file itself.
* Exposed the `MessageBase` class directly from extract_msg. I forgot to do this when I created it.
* Added `MessageBase.bcc`. I think it used to exist but got erased somehow on accident. Either way, it exists now.