### PR TITLE
Version 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.54.2**
+* [[TeamMsgExtractor #465](https://github.com/TeamMsgExtractor/msg-extractor/issues/465)] Added missing `msg.close()` to `openMsg()`. If the MSG file was actually just a plain OLE file, it would be left open.
+
 **v0.54.1**
 * [[TeamMsgExtractor #462](https://github.com/TeamMsgExtractor/msg-extractor/issues/462)] Fix potential issue where child MSG might have incompatible encoding to parent MSG when trying to grab a stream from the parent.
 * Added code to attempt to significantly improve RTF deencapsulation times. This tries to strip away unneeded data before passing it to `RTFDE`. This shows improvements on all files that take more than one second. Currently, this actually fixes some files previously outputting wrong from `RTFDE` when deencapsulating the HTML body, specifically around non breaking spaces sometimes not transferring over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-**v0.54.2**
+**v0.55.0**
 * [[TeamMsgExtractor #465](https://github.com/TeamMsgExtractor/msg-extractor/issues/465)] Added missing `msg.close()` to `openMsg()`. If the MSG file was actually just a plain OLE file, it would be left open.
+* Adjusted the default value of `maxNameLength` for `MessageBase.save()` to 40 instead of 256.
+* Adjusted exception handling for `MessageBase.save()` to properly report the reason a folder fails to be created.
+* Simplified some of the code for `MessageBase.save()`.
+* Fixed some typing information.
 
 **v0.54.1**
 * [[TeamMsgExtractor #462](https://github.com/TeamMsgExtractor/msg-extractor/issues/462)] Fix potential issue where child MSG might have incompatible encoding to parent MSG when trying to grab a stream from the parent.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.54.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.54.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.55.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.55.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2025-04-10'
-__version__ = '0.54.1'
+__date__ = '2025-05-17'
+__version__ = '0.54.2'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2025-05-17'
-__version__ = '0.54.2'
+__date__ = '2025-08-12'
+__version__ = '0.55.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/attachments/attachment.py
+++ b/extract_msg/attachments/attachment.py
@@ -13,7 +13,7 @@ import random
 import string
 import zipfile
 
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from .. import constants
 from .attachment_base import AttachmentBase
@@ -72,7 +72,7 @@ class Attachment(AttachmentBase):
 
         return filename
 
-    def regenerateRandomName(self) -> str:
+    def regenerateRandomName(self) -> None:
         """
         Used to regenerate the random filename used if the attachment cannot
         find a usable filename.
@@ -166,9 +166,11 @@ class Attachment(AttachmentBase):
                 _zip.close()
 
     @property
-    def data(self) -> bytes:
+    def data(self) -> Optional[bytes]:
         """
         The bytes making up the attachment data.
+
+        If the attachment data stream does not exist, returns None.
         """
         return self.__data
 

--- a/extract_msg/open_msg.py
+++ b/extract_msg/open_msg.py
@@ -109,6 +109,7 @@ def openMsg(path, **kwargs) -> MSGFile:
     # lower function. So let's make sure we got a good return first.
     if not ct:
         if kwargs.get('strict', True):
+            msg.close()
             raise InvalidFileFormatError('File was confirmed to be an olefile, but was not an MSG file.')
         else:
             # If strict mode is off, we'll just return an MSGFile anyways.


### PR DESCRIPTION
**v0.55.0**
* [[TeamMsgExtractor #465](https://github.com/TeamMsgExtractor/msg-extractor/issues/465)] Added missing `msg.close()` to `openMsg()`. If the MSG file was actually just a plain OLE file, it would be left open.
* Adjusted the default value of `maxNameLength` for `MessageBase.save()` to 40 instead of 256.
* Adjusted exception handling for `MessageBase.save()` to properly report the reason a folder fails to be created.
* Simplified some of the code for `MessageBase.save()`.
* Fixed some typing information.
