### PR TITLE
Allow ebcdic 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**vNext**
+* [[TeamMsgExtractor #478](https://github.com/TeamMsgExtractor/msg-extractor/issues/478)] Expand allowable versions of `ebcdic` to include `2.x`. The 2.0 release is a pure technical release with no functional changes; it only drops support for Python 2 and 3.8. The lower bound is unchanged so installs on Python 3.8 will continue to resolve to `ebcdic 1.1.1`.
+
 **v0.55.0**
 * [[TeamMsgExtractor #465](https://github.com/TeamMsgExtractor/msg-extractor/issues/465)] Added missing `msg.close()` to `openMsg()`. If the MSG file was actually just a plain OLE file, it would be left open.
 * Adjusted the default value of `maxNameLength` for `MessageBase.save()` to 40 instead of 256.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 olefile==0.47
 tzlocal>=4.2,<6
 compressed-rtf>=1.0.6,<2
-ebcdic>=1.1.1,<2
+ebcdic>=1.1.1,<3
 beautifulsoup4>=4.11.1,<4.14
 RTFDE>=0.1.1,<0.2
 red-black-tree-mod>=1.20, <=1.23


### PR DESCRIPTION
- [x] Issue #: #478
- [x] Have you listed any changes to install or build dependencies? Yes — `requirements.txt`: `ebcdic>=1.1.1,<2` → `ebcdic>=1.1.1,<3`.
- [ ] Ensured your changes are compatible with Python 2.7 (ONLY FOR v0.29). N/A (this PR targets `next-release`).
- [x] Have you updated the [CHANGELOG](CHANGELOG.md) with details of changes to the codebase, this includes new functionality, deprecated features, or any other material changes.
- [ ] If necessary, have you bumped the version number? We will usually do this for you. (Left for maintainers.)
- [x] Have you included py.test tests with your pull request. (Not yet necessary) — no new tests; existing `tests.py` suite passes locally with `ebcdic==2.0.1` installed.
- [x] Ensured your code is as close to PEP 8 compliant as possible? `flake8 . --select=E9,F63,F7,F82` clean.
- [x] Ensured your pull request is to the `next-release` branch (or `v0.29` if applicable)?

## Summary

Resolves #478. Per the [ebcdic changelog](https://github.com/roskakori/CodecMapper/blob/master/CHANGES.md), the 2.0 release is "a pure technical release that does not change the functionality of the package" — it only modernizes the build toolchain and drops support for Python 2 and 3.8.

Because `extract_msg` still supports Python 3.8 (per `setup.py` and the CI matrix in `.github/workflows/python-package.yml`), this PR widens the upper bound instead of requiring `ebcdic>=2`. The lower bound is unchanged, so on Python 3.8 pip will continue to resolve to `ebcdic 1.1.1`; on Python 3.9+ it can now also pick up `2.x`.

This is analogous to #469 / #472 for `beautifulsoup4`.

## Verification

- `extract_msg/encoding/__init__.py` uses `ebcdic` only as `import ebcdic as _` to register codecs on import. Confirmed all EBCDIC code pages referenced in `_CODE_PAGES` (e.g. `cp1140`, `cp1141`, `cp1148ms`, `cp290`, `cp420`, `cp424`, `cp833`, `cp838`, `cp870`, `cp1097`, `cp1149`, `cp273`, `cp277`, `cp278`, `cp280`, `cp284`, `cp285`, `cp297`, `cp1025`) resolve via `codecs.lookup()` with `ebcdic==2.0.1` installed.
- `python tests.py`: 20 passed, 2 skipped (user-test-files-only).
- `flake8 . --select=E9,F63,F7,F82`: 0 issues.