### PR TITLE
Version 0.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.56.1**
+* [[TeamMsgExtractor #484](https://github.com/TeamMsgExtractor/msg-extractor/issues/484)] Corrected the way the HTML body is decoded in `MessageBase.asEmailMessage()` to prevent encoding errors.
+
 **v0.56.0**
 * [[TeamMsgExtractor #478](https://github.com/TeamMsgExtractor/msg-extractor/issues/478)] Expand allowable versions of `ebcdic` to include `2.x`. The 2.0 release is a pure technical release with no functional changes; it only drops support for Python 2 and 3.8. The lower bound is unchanged so installs on Python 3.8 will continue to resolve to `ebcdic 1.1.1`.
 * [[TeamMsgExtractor #469](https://github.com/TeamMsgExtractor/msg-extractor/issues/469)] Expanded `beautifulsoup` to allow for versions up to `5.*.*`. I was previously hesitant to do so because they sometimes do what seems like non backwards compatible changes in minor versions, but it looks like this should be fine.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.56.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.56.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.56.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.56.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2026-07-18'
-__version__ = '0.56.0'
+__date__ = '2026-08-13'
+__version__ = '0.56.1'
 
 __all__ = [
     # Modules:

--- a/extract_msg/msg_classes/message_base.py
+++ b/extract_msg/msg_classes/message_base.py
@@ -294,7 +294,7 @@ class MessageBase(MSGFile):
         if self.body:
             bodyParts.attach(MIMEText(self.body, 'plain', c))
         if self.htmlBody:
-            bodyParts.attach(MIMEText(self.htmlBody.decode('utf-8'), 'html', c))
+            bodyParts.attach(MIMEText(str(bs4.BeautifulSoup(self.htmlBody)), 'html', c))
 
         # Process attachments.
         for att in self.attachments:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -458,7 +458,7 @@ def getCommandArgs(args: Sequence[str]) -> argparse.Namespace:
                         help='Extracts the embedded MSG files as MSG files instead of running their save functions.')
     # --overwrite-existing
     parser.add_argument('--overwrite-existing', dest='overwriteExisting', action='store_true',
-                        help='Disables filename conflict resolution code for attachments when saving a file, causing files to be overwriten if two attachments with the same filename are on an MSG file.')
+                        help='Disables filename conflict resolution code for attachments when saving a file, causing files to be overwritten if two attachments with the same filename are on an MSG file.')
     # --skip-not-implemented
     parser.add_argument('--skip-not-implemented', '--skip-ni', dest='skipNotImplemented', action='store_true',
                         help='Skips any attachments that are not implemented, allowing saving of the rest of the message.')


### PR DESCRIPTION
**v0.56.1**
* [[TeamMsgExtractor #484](https://github.com/TeamMsgExtractor/msg-extractor/issues/484)] Corrected the way the HTML body is decoded in `MessageBase.asEmailMessage()` to prevent encoding errors.